### PR TITLE
Adds LICENSE to excluded files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -68,6 +68,7 @@ defaults:
 exclude:
   - Makefile
   - bin
+  - LICENSE
 
 # Turn off built-in syntax highlighting.
 highlighter: false


### PR DESCRIPTION
Otherwise viewing it locally fails (at least with the jekyll/jekyll Docker container).